### PR TITLE
[Solve] : [BOJ] 창고 다각형 문제 해결

### DIFF
--- a/Minwoo/BOJ/2304/sol.py
+++ b/Minwoo/BOJ/2304/sol.py
@@ -1,0 +1,45 @@
+import sys
+sys.stdin = open('input.txt', 'r')
+
+N = int(input())
+data = sorted([tuple(map(int, input().split())) for _ in range(N)])
+P = [0] * (data[-1][0]+1)
+forward_sum, reverse_sum = 0, 0
+max_idx, max_val = -1, -1
+for i in range(N):
+    if max_val < data[i][1]:
+        max_idx = i
+        max_val = data[i][1]
+
+
+def install(start, end, increase, length):
+    for k in range(start, end, increase):
+        P[k] = length
+
+
+# 정방향으로 가다가 가장 큰 기둥을 만나면 종료
+for i in range(max_idx):
+    if P[data[i][0]]: continue
+    for j in range(i+1, max_idx):
+        if data[i][1] < data[j][1]:
+            ni = j
+            break
+    else:
+        install(data[i][0], data[max_idx][0], 1, data[i][1])
+        continue
+    install(data[i][0], data[ni][0], 1, data[i][1])
+
+# 역방향으로 가다가 가장 큰 기둥을 만나면 종료
+for i in range(N-1, max_idx, -1):
+    if P[data[i][0]]: continue
+    for j in range(i-1, max_idx, -1):
+        if data[i][1] < data[j][1]:
+            ni = j
+            break
+    else:
+        install(data[i][0], data[max_idx][0], -1, data[i][1])
+        continue
+    install(data[i][0], data[ni][0], -1, data[i][1])
+# 마지막으로 가장 큰 기둥값을 더한다.
+P[data[max_idx][0]] = max_val
+print(sum(P))


### PR DESCRIPTION
- 제목 : [Solve] : [BOJ] 2304 창고다각형 - 문제 해결
- 내용 : 문제 링크, 풀이 코드, 풀이 방법 설명

# [2304번 창고 다각형](https://www.acmicpc.net/problem/2304)

## 문제 코드
```python
N = int(input())
data = sorted([tuple(map(int, input().split())) for _ in range(N)])
P = [0] * (data[-1][0]+1)
forward_sum, reverse_sum = 0, 0
max_idx, max_val = -1, -1
for i in range(N):
    if max_val < data[i][1]:
        max_idx = i
        max_val = data[i][1]


def install(start, end, increase, length):
    for k in range(start, end, increase):
        P[k] = length


# 정방향으로 가다가 가장 큰 기둥을 만나면 종료
for i in range(max_idx):
    if P[data[i][0]]: continue
    for j in range(i+1, max_idx):
        if data[i][1] < data[j][1]:
            ni = j
            break
    else:
        install(data[i][0], data[max_idx][0], 1, data[i][1])
        continue
    install(data[i][0], data[ni][0], 1, data[i][1])

# 역방향으로 가다가 가장 큰 기둥을 만나면 종료
for i in range(N-1, max_idx, -1):
    if P[data[i][0]]: continue
    for j in range(i-1, max_idx, -1):
        if data[i][1] < data[j][1]:
            ni = j
            break
    else:
        install(data[i][0], data[max_idx][0], -1, data[i][1])
        continue
    install(data[i][0], data[ni][0], -1, data[i][1])
# 마지막으로 가장 큰 기둥값을 더한다.
P[data[max_idx][0]] = max_val
print(sum(P))

```

## 풀이 방식
- 가장 높은 기둥을 기준으로 좌우를 나누어서 탐색
- 가장 큰 기둥을 만나기 전까지 배열을 채우고, 뒤집어서 탐색
- 마지막에 가장 큰 기둥을 더해준 후에 sum을 사용하여 출력