### PR TITLE
[Solve] : [BOJ] 2635 수 이어가기 문제 해결

### DIFF
--- a/minsun/BOJ/2635/sol.py
+++ b/minsun/BOJ/2635/sol.py
@@ -1,0 +1,48 @@
+import sys
+sys.stdin = open("input.txt", "r")
+
+N = int(input())
+
+result = []
+
+for next in range(1, N+1):
+    arr = []
+    first_num = N
+    second_num = next
+    arr = [first_num, second_num]
+
+    temp_num = first_num
+
+    while True:
+        third_num = temp_num - second_num
+
+        # if third_num < 0:
+        #     break
+        #
+        # arr.append(third_num)
+        # temp_num = second_num
+        # second_num = third_num
+
+
+        if third_num >= 0:
+            arr.append(third_num)
+            temp_num = second_num
+            second_num = third_num
+        else:
+            break
+
+
+
+        if len(result) < len(arr):
+            result = []
+            result = arr
+
+
+print(len(result))
+print(*result)
+
+
+
+
+
+


### PR DESCRIPTION
[BOJ] 2635:
    - 문제 유형 : 브루트 포스
    - 문제 난이도 : 백준 실버 5
    - 시간 : 60ms

- 내용 : https://www.acmicpc.net/problem/2635

## 문제 코드
```python
N = int(input())

result = []

for next in range(1, N+1):
    arr = []
    first_num = N
    second_num = next
    arr = [first_num, second_num]

    temp_num = first_num

    while True:
        third_num = temp_num - second_num

        # if third_num < 0:
        #     break
        #
        # arr.append(third_num)
        # temp_num = second_num
        # second_num = third_num

        if third_num >= 0:
            arr.append(third_num)
            temp_num = second_num
            second_num = third_num
        else:
            break

        if len(result) < len(arr):
            result = []
            result = arr


print(len(result))
print(*result)
```

## 풀이 방식
- 첫번째 수랑 두번째 수를 넣어주고, 다음 숫자가 0보다 크거나 갖다면 세번째 숫자를 넣어주고, 다음 숫자를 계속 바꿔주는 식으로 풀었다.
- 처음에 0은 포함하지 않는 줄 알고 third_num > 0 보다 큰 조건으로 설정했는데 1을 넣었을 때 0 이 나오는 반례가 생겨서 틀렸던 것