### PR TITLE
[Fail] : [BOJ] 1959 달팽이 3 - 해결 중

### DIFF
--- a/Minwoo/BOJ/1959/sol.py
+++ b/Minwoo/BOJ/1959/sol.py
@@ -1,0 +1,25 @@
+import sys
+sys.stdin = open('input.txt', 'r')
+
+R, C = map(int, sys.stdin.readline().split())
+visited_row, visited_col = set(), set()
+row, col = 0, C-1
+rc, cc = 0, 0
+
+i = 0
+prev_row, prev_col = row, col
+while True:
+    i += 1
+    # 짝수는 열을 변경
+    if i % 2 == 0:
+        col = C-1 - (col - cc)
+        cc = -(1 if cc == 0 else 0)
+
+    # 홀수는 행을 변경
+    else:
+        row = R-1 - (row + rc)
+        rc = -(1 if rc == 0 else 0)
+    if prev_row == row and prev_col == col:
+        break
+    prev_row, prev_col = row, col
+print(f'{i-1}\n{row+1} {col+1}')


### PR DESCRIPTION
- 제목 :[Fail] : [BOJ] 1959 달팽이 3 - 해결 중
- 내용 : 문제 링크, 풀이 코드, 풀이 방법 설명
    - 문제 난이도 : Gold 3
    - 문제 분류: 수학, 많은 조건 분기

# [1959 - 달팽이3](https://www.acmicpc.net/problem/1959)

## 문제 코드
```python
import sys

R, C = map(int, sys.stdin.readline().split())
visited_row, visited_col = set(), set()
row, col = 0, C-1
rc, cc = 0, 0

i = 0
prev_row, prev_col = row, col
while True:
    i += 1
    # 짝수는 열을 변경
    if i % 2 == 0:
        col = C-1 - (col - cc)
        cc = -(1 if cc == 0 else 0)

    # 홀수는 행을 변경
    else:
        row = R-1 - (row + rc)
        rc = -(1 if rc == 0 else 0)
    if prev_row == row and prev_col == col:
        break
    prev_row, prev_col = row, col
print(f'{i-1}\n{row+1} {col+1}')

```

## 풀이 방식
- 완전탐색으로 같은 좌표를 2번 탐색하는 경우 탐색을 종료합니다.

## 오류
- 시간 초과 발생: 
    1.  탐색이 아닌 좌표를 한번에 찾는 방법을 찾아야 합니다.
    2. 좌표를 찾으면서 동시에 몇번 반복하는지도 확인해야 합니다.