### PR TITLE
[Solve] : [BOJ] 1347 미로 만들기 문제 해결

### DIFF
--- a/kimchaejun/BOJ/1347/sol.py
+++ b/kimchaejun/BOJ/1347/sol.py
@@ -1,0 +1,25 @@
+N = int(input())
+move = str(input())
+dxy = [[1, 0], [0, 1], [-1, 0], [0, -1]]
+H, W, order = 0, 0, 0
+up_down, left_right, route = [0], [0], []
+for m in move:
+    if m == 'L':
+        order = (order + 1) % 4
+    elif m == 'R':
+        order = 3 if order-1 < 0 else order-1
+    else:
+        H, W = H + dxy[order][0], W + dxy[order][1]
+        up_down.append(H)
+        left_right.append(W)
+        route.append((H, W))
+ud_set, lr_set = sorted(set(up_down)), sorted(set(left_right))
+height = len(ud_set)
+width = len(lr_set)
+sx, sy = ud_set.index(0), lr_set.index(0)
+maze = [['#']*width for _ in range(height)]
+maze[sx][sy] = '.'
+for x, y in route:
+    maze[sx + x][sy + y] = '.'
+for m in maze:
+    print(''.join(m))


### PR DESCRIPTION
- 제목 : [Solve] [BOJ] 1347 - 미로 만들기 문제 해결
- 내용 : 문제 링크, 풀이 코드, 풀이 방법 설명
## 문제 링크 : https://www.acmicpc.net/problem/1347

## 문제 코드
```python
N = int(input())
move = str(input())
dxy = [[1, 0], [0, 1], [-1, 0], [0, -1]]
H, W, order = 0, 0, 0
up_down, left_right, route = [0], [0], []
for m in move:
    if m == 'L':
        order = (order + 1) % 4
    elif m == 'R':
        order = 3 if order-1 < 0 else order-1
    else:
        H, W = H + dxy[order][0], W + dxy[order][1]
        up_down.append(H)
        left_right.append(W)
        route.append((H, W))
ud_set, lr_set = sorted(set(up_down)), sorted(set(left_right))
height = len(ud_set)
width = len(lr_set)
sx, sy = ud_set.index(0), lr_set.index(0)
maze = [['#']*width for _ in range(height)]
maze[sx][sy] = '.'
for x, y in route:
    maze[sx + x][sy + y] = '.'
for m in maze:
    print(''.join(m))
```

## 풀이 방식
- 기본 진행 방향이 남쪽, 즉 아래쪽이기 때문에 이에 맞게 dxy(델타 탐색용 좌표값)를 선언한다.
- 시작점이 (0 , 0)이라고 가정하고, H와 W 값을 변경한다.
- 미로를 만들 때, 시작 지점과 이동 방향을 빠르게 계산하기 위해 각각의 리스트에 값을 저장해놓는다.
- 겹치는 좌표를 set하여 오름차순으로 정렬한 뒤 찾은 0의 인덱스 번호가 홍준이의 시작 위치이다.
- 미로의 크기는 겹치는 좌표를 set하고 남은 변수의 길이이다.
- 기본 값은 '#'으로 두고 미로를 만든다.
- 시작 지점을 '.'으로 바꿔주고, 시작 좌표 + 저장해놓은 이동했던 좌표값의 위치에 값을 '.'으로 바꾼다.
- 작업이 완료된 후,  join을 사용하여 하나의 문자열로 만들면서 한줄씩 출력한다.

## 시간 복잡도 (GPT 사용)
- 최선 : O(N)
- 평균 : O(N log N) ~ O(N²)
- 최악 : O(N²)