### PR TITLE
[Solved] : SWEA/5643 키 순서 문제 해결

### DIFF
--- a/comet/SWEA/5643/sol.py
+++ b/comet/SWEA/5643/sol.py
@@ -1,0 +1,53 @@
+import sys
+sys.stdin = open("input.txt", "r")
+#############################################
+## 시간복잡도 : 921ms
+## 공간복잡도 : 92288kb
+def dfs(idx):
+    global up, num, down, result
+    sum_val = 0
+    visit = [0] * (num + 1)
+    visit[idx] = 1
+    cnt = 0
+
+    stack = [idx]
+    while stack:
+        current = stack.pop()
+
+        for i in up[current]:
+            if not visit[i]:
+                stack.append(i)
+                visit[i] = 1
+                cnt += 1
+
+    stack = [idx]
+    while stack:
+        current = stack.pop()
+
+        for i in down[current]:
+            if not visit[i]:
+                stack.append(i)
+                visit[i] = 1
+                cnt += 1
+    if cnt == num - 1:
+        result += 1
+
+T = int(input())
+for tc in range(1, T+1):
+    num = int(input().strip())
+    compare = int(input().strip())
+    up = {}
+    down = {}
+    result = 0
+    for i in range(1, num + 1):
+        up[i] = []
+        down[i] = []
+    for _ in range(compare):
+        a, b = map(int, input().split())        # a < b
+        up[a].append(b)
+        down[b].append(a)
+
+
+    for i in range(1, num + 1):
+        dfs(i)
+    print(f'#{tc} {result}')


### PR DESCRIPTION
[5643 키 순서](https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AWXQsLWKd5cDFAUo)
## 문제 코드
```python
## 시간복잡도 : 921ms
## 시간복잡도 : 887ms(그래프 리스트로 변경 후 재채점)
## 공간복잡도 : 92288kb

def dfs(idx):
    global up, num, down, result
    sum_val = 0
    visit = [0] * (num + 1)
    visit[idx] = 1
    cnt = 0

    stack = [idx]
    while stack:                     # 더 큰 학생 탐색
        current = stack.pop()

        for i in up[current]:
            if not visit[i]:
                stack.append(i)
                visit[i] = 1
                cnt += 1

    stack = [idx]
    while stack:                    # 더 작은 학생 탐색
        current = stack.pop()

        for i in down[current]:
            if not visit[i]:
                stack.append(i)
                visit[i] = 1
                cnt += 1
    if cnt == num - 1:         # 다른 모든 학생과 상 하 관계가 정립되었으면, 결과에 1추가
        result += 1

T = int(input())
for tc in range(1, T+1):
    num = int(input().strip())
    compare = int(input().strip())
    up = {}
    down = {}
    result = 0
    for i in range(1, num + 1):
        up[i] = []
        down[i] = []
    for _ in range(compare):
        a, b = map(int, input().split())        # 상 하 관계 그래프 따로 제작
        up[a].append(b)
        down[b].append(a)


    for i in range(1, num + 1):
        dfs(i)
    print(f'#{tc} {result}')
```

## 풀이 방식
- 1번부터 n 번 학생까지 dfs 탐색
- 자신보다 큰 학생과 자신보다 작은 학생의 수가 n - 1이면 == 다른 모든 학생에 대한 상하관계가 정립되어있으면
- 결과에 1추가 
- 딕셔너리 말고 걍 리스트로 하니 887ms로 줄어드네용