### PR TITLE
[Solve] : [BOJ] 2167 - 2차원 배열의 합 문제 해결

### DIFF
--- a/minsun/BOJ/2167/sol.py
+++ b/minsun/BOJ/2167/sol.py
@@ -1,0 +1,16 @@
+import sys
+sys.stdin = open('input.txt', 'r')
+
+N, M = map(int, sys.stdin.readline().split())
+matrix = [list(map(int, sys.stdin.readline().split())) for _ in range(N)]
+
+K = int(sys.stdin.readline())
+for _ in range(K):
+    i, j, x, y = map(int, sys.stdin.readline().split())
+    result = 0
+
+    for k in range(i-1, x):
+        for l in range(j-1, y):
+            result+=matrix[k][l]
+
+    print(result)


### PR DESCRIPTION
[BOJ] 2167:
    - 문제 유형 : 누적합인줄알았으나 dp
    - 시간 : 3328ms
    - 문제 난이도 : 실버 5

- 내용 : [문제 링크](https://www.acmicpc.net/problem/2167)


## 문제 코드
```python
import sys

N, M = map(int, sys.stdin.readline().split())
matrix = [list(map(int, sys.stdin.readline().split())) for _ in range(N)]

K = int(sys.stdin.readline())
for _ in range(K):
    i, j, x, y = map(int, sys.stdin.readline().split())
    result = 0

    for k in range(i-1, x):
        for l in range(j-1, y):
            result+=matrix[k][l]

    print(result)
```

## 풀이 방식
- 2 차원 배열 인덱싱 연습하려고 했는데... 그냥 input 받고 완탐으로 더하면 시간초과남 pypy + readline 써야 함
- 찾아보니까 DP 문제였음 대혜성이 풀어주길