### PR TITLE
[Solve] : [BOJ] 2206 벽 부수고 이동하기 - 문제 해결

### DIFF
--- a/Minwoo/BOJ/2206/sol.py
+++ b/Minwoo/BOJ/2206/sol.py
@@ -1,0 +1,36 @@
+import sys
+from collections import deque
+
+
+def BFS():
+    global N, M, grid, result
+    dkx = [1, 0, -1, 0]
+    dky = [0, 1, 0, -1]
+    visited = [[[False] * M for _ in range(N)] for __ in range(2)]
+    queue = deque([[0, 0, 1, 1]])
+    visited[1][0][0] = True
+    while queue:
+        x, y, k, cnt = queue.popleft()
+        if (x, y) == (N-1, M-1):
+            result = min(result, cnt)
+            continue
+        cnt += 1
+        for dx, dy in zip(dkx, dky):
+            nx, ny = x + dx, y + dy
+            if not(0 <= nx < N and 0 <= ny < M):
+                continue
+            if visited[k][nx][ny]: continue
+            if grid[nx][ny] == '1':
+                if k > 0:
+                    queue.append([nx, ny, 0, cnt])
+                    visited[0][nx][ny] = True
+                continue
+            queue.append([nx, ny, k, cnt])
+            visited[k][nx][ny] = True
+
+
+N, M = map(int, input().split())
+grid = [list(sys.stdin.readline().strip()) for _ in range(N)]
+result = float('inf')
+BFS()
+print(result if result != float('inf') else -1)


### PR DESCRIPTION
- 제목 : [Solve] : [BOJ] 2206 벽 부수고 이동하기 - 문제 해결
- 내용 : 문제 링크, 풀이 코드, 풀이 방법 설명
    - 문제 난이도 - Gold 3
    - 문제 분류 - 너비 우선 탐색

# [BOJ 2206 - 벽 부수고 이동하기](https://www.acmicpc.net/problem/2206)
## 문제 코드
```python
import sys
from collections import deque


def BFS():
    global N, M, grid, result
    dkx = [1, 0, -1, 0]
    dky = [0, 1, 0, -1]
    visited = [[[False] * M for _ in range(N)] for __ in range(2)]
    queue = deque([[0, 0, 1, 1]])
    visited[1][0][0] = True
    while queue:
        x, y, k, cnt = queue.popleft()
        if (x, y) == (N-1, M-1):
            result = min(result, cnt)
            continue
        cnt += 1
        for dx, dy in zip(dkx, dky):
            nx, ny = x + dx, y + dy
            if not(0 <= nx < N and 0 <= ny < M):
                continue
            if visited[k][nx][ny]: continue
            if grid[nx][ny] == '1':
                if k > 0:
                    queue.append([nx, ny, 0, cnt])
                    visited[0][nx][ny] = True
                continue
            queue.append([nx, ny, k, cnt])
            visited[k][nx][ny] = True


N, M = map(int, input().split())
grid = [list(sys.stdin.readline().strip()) for _ in range(N)]
result = float('inf')
BFS()
print(result if result != float('inf') else -1)

```

## 풀이 방식
- 벽은 한번만 부쉴 수 있습니다. 따라서 3차원 배열로 방문처리를 합니다
    - 가장 큰 이유는 벽을 부쉬고 지나갔는데 나중에 돌아온 경우에 지나가야 함에도 지나가지 못하는 상황을 방지합니다.
- 나머지는 BFS에 기초해서 문제를 풀었습니다.

## 여담
- GPT한테 최적화 뭐 하면 좋을 지 물어보고 했는데 더 오래걸렸습니다 ~~할루시네이션 ㄸㅂ~~