### PR TITLE
[Solve]:[BOJ] 1996 지뢰찾기 문제 해결

### DIFF
--- a/kimchaejun/BOJ/1996/sol.py
+++ b/kimchaejun/BOJ/1996/sol.py
@@ -1,0 +1,17 @@
+N = int(input())
+mine = [input() for _ in range(N)]
+res = [['0']*N for _ in range(N)]
+dxy = [[0, 1], [0, -1], [1, 0], [-1, 0], [1, 1], [1, -1], [-1, 1], [-1, -1]]
+point = []
+for i in range(N):
+    for j in range(N):
+        if mine[i][j] == '.':
+            continue
+        res[i][j] = '*'
+        for dx, dy in dxy:
+            nx, ny = i + dx, j + dy
+            if 0 <= nx < N and 0 <= ny < N and res[nx][ny] != '*' and res[nx][ny] != 'M':
+                tmp = int(mine[i][j]) + int(res[nx][ny])
+                res[nx][ny] = str(tmp) if tmp < 10 else 'M'
+for i in range(N):
+    print(''.join(res[i]))


### PR DESCRIPTION
- 제목 : [Solve]:[BOJ] 1996 지뢰찾기 문제 해결
- 내용 : 문제 링크, 풀이 코드, 풀이 방법 설명
## 문제 링크 : [1996 지뢰찾기](https://www.acmicpc.net/problem/1996)

## 문제 코드
```python
N = int(input())
mine = [input() for _ in range(N)]
res = [['0']*N for _ in range(N)]
dxy = [[0, 1], [0, -1], [1, 0], [-1, 0], [1, 1], [1, -1], [-1, 1], [-1, -1]]
point = []
for i in range(N):
    for j in range(N):
        if mine[i][j] == '.':
            continue
        res[i][j] = '*'
        for dx, dy in dxy:
            nx, ny = i + dx, j + dy
            if 0 <= nx < N and 0 <= ny < N and res[nx][ny] != '*' and res[nx][ny] != 'M':
                tmp = int(mine[i][j]) + int(res[nx][ny])
                res[nx][ny] = str(tmp) if tmp < 10 else 'M'
for i in range(N):
    print(''.join(res[i]))
```

## 풀이 방식
- 입력을 2차원 배열로 저장
- 입력을 델타탐색하며 숫자, 즉 지뢰 개수를 찾으면 주변 범위에 해당 좌표의 지뢰 개수를 더한다.
- 계산 결과가 10이 넘으면 추가로 더 연산을 진행하지 않게끔 M으로 값을 저장한다.
- 출력을 맞춰주기 위해 결과는 모두 문자열로 저장한다.
- join을 사용해 정답을 출력한다.

## 시간 복잡도 (GPT 사용)
- 최선, 평균, 최악 모두 다 O(N²)이다.
- 다만, 폭탄 개수에 따라서 실행 시간에 차이가 생깁니다.