### PR TITLE
[Solved] : BOJ/10942 문제해결

### DIFF
--- a/comet/BOJ/10942/sol.py
+++ b/comet/BOJ/10942/sol.py
@@ -1,0 +1,27 @@
+import sys
+sys.stdin = open("input.txt", "r")
+from pprint import pprint
+#############################################
+## pypy3
+## 시간복잡도 : 768ms
+## 공간복잡도 : 214848kb
+length = int(input().strip())
+arr = [0] + list(map(int, input().split()))
+num = int(input())
+dp = [[0] * (length + 1) for _ in range(length + 1)]
+
+for i in range(1, length + 1):
+    dp[i][i] = 1
+    if arr[i] == arr[i - 1]:
+        dp[i][i - 1] = 1
+    for j in range(i-2, 0, -1):
+        if arr[i] == arr[j]:
+            if dp[i - 1][j + 1]:
+                dp[i][j] = 1
+result = []
+for _ in range(num):
+    a, b = map(int, input().split())
+    result.append(dp[b][a])
+
+print('\n'.join(map(str, result)))
+


### PR DESCRIPTION
문제 난이도 : 골드 4
문제 유형 : DP
# readline 안쓰려고 별짓을 다 해봤읍니다.... 
[BOJ/10942](https://www.acmicpc.net/problem/10942)

## 문제 코드
```python
## pypy3
## 시간복잡도 : 768ms
## 공간복잡도 : 214848kb
length = int(input().strip())
arr = [0] + list(map(int, input().split()))
num = int(input())
dp = [[0] * (length + 1) for _ in range(length + 1)]

for i in range(1, length + 1):
    dp[i][i] = 1
    if arr[i] == arr[i - 1]:
        dp[i][i - 1] = 1
    for j in range(i-2, 0, -1):
        if arr[i] == arr[j]:
            if dp[i - 1][j + 1]:
                dp[i][j] = 1
result = []
for _ in range(num):
    a, b = map(int, input().split())
    result.append(dp[b][a])

print('\n'.join(map(str, result)))
```

## 풀이 방식
- 두 점을 찍었을 때 (a, b) 사이가 펠린드롬인지 판단하기위해 dp를 통해 모두 구해놓은 후 한꺼번에 출력함.
- 1 부터 n 까지 탐색 n, n 은 길이가 1이라 무조건 펠린트롬이니 dp[n][n] 을 1로 만든다.
- n 과 n - 1 에 대해서도 두개의 값이 같으면 무조건 펠린드롬이니 같을 경우에 1로 만들어주고, 
- 그 다음부턴 두 점의 값이 같을 때(a, b) a와 b 사이가 펠린드롬이면 펠린드롬이 되니 이전에 구해놓은 dp[i - 1][j + 1] 을 바로 참조해와서 판단함. 
- 시간초과가 나서 고민 많이 했는데 print 가 제일 문제였음... print 를 100만번 하니 readline 안쓰곤 통과 못함 .
- readline  빼고 결과를 배열에 모았다가 '\n' (줄 바꿈 문자) 와 함께 join 으로 묶어주니 통과.