### PR TITLE
[Solve] : [BOJ] 14442 벽 부수고 이동하기2 - 문제해결

### DIFF
--- a/Minwoo/BOJ/14442/sol_refactor.py
+++ b/Minwoo/BOJ/14442/sol_refactor.py
@@ -1,0 +1,38 @@
+from collections import deque
+import sys
+sys.stdin = open('input.txt', 'r')
+
+input = sys.stdin.readline
+dxy = [(1, 0), (0, 1), (0, -1), (-1, 0)]
+
+
+def bfs():
+    global N, M, K, grid
+    visited = [[[0] * (K+1) for _ in range(M)] for _ in range(N)]
+    queue = deque([(0, 0, K, 1)])
+
+    visited[0][0][K] = 1
+    while queue:
+        x, y, z, cnt = queue.popleft()
+        if x == N-1 and y == M-1:
+            return cnt
+        cnt += 1
+        for dx, dy in dxy:
+            nx, ny = x + dx, y + dy
+            # 방문처리
+            if nx < 0 or nx >= N or ny < 0 or ny >= M:
+                continue
+            # 벽일때
+            if grid[nx][ny] == 1 and z > 0 and visited[nx][ny][z-1] == 0:
+                queue.append((nx, ny, z-1, cnt))
+                visited[nx][ny][z-1] = 1
+            # 벽 아닐때
+            if grid[nx][ny] == 0 and visited[nx][ny][z] == 0:
+                queue.append((nx, ny, z, cnt))
+                visited[nx][ny][z] = 1
+    return -1
+
+
+N, M, K = map(int, input().split())
+grid = [list(map(int, input().strip())) for _ in range(N)]
+print(bfs())


### PR DESCRIPTION
- 제목 : [Solve] : [BOJ] 14442 벽 부수고 이동하기2 - 문제해결
- 내용 : 문제 링크, 풀이 코드, 풀이 방법 설명
    - 문제 난이도 : Gold 3
    - 문제 유형 : 너비우선탐색
    - Runtime : pypy일때 5472ms
    - TMI : 13번 틀림

# [BOJ 14442 벽 부수고 이동하기 2](https://www.acmicpc.net/problem/14442)
## 문제 코드
```python
from collections import deque
import sys
input = sys.stdin.readline
dxy = [(1, 0), (0, 1), (0, -1), (-1, 0)]


def bfs():
    global N, M, K, grid
    visited = [[[0] * (K+1) for _ in range(M)] for _ in range(N)]
    queue = deque([(0, 0, K, 1)])

    visited[0][0][K] = 1
    while queue:
        x, y, z, cnt = queue.popleft()
        if x == N-1 and y == M-1:
            return cnt
        cnt += 1
        for dx, dy in dxy:
            nx, ny = x + dx, y + dy
            # 방문처리
            if nx < 0 or nx >= N or ny < 0 or ny >= M:
                continue
            # 벽일때
            if grid[nx][ny] == 1 and z > 0 and visited[nx][ny][z-1] == 0:
                queue.append((nx, ny, z-1, cnt))
                visited[nx][ny][z-1] = 1
            # 벽 아닐때
            if grid[nx][ny] == 0 and visited[nx][ny][z] == 0:
                queue.append((nx, ny, z, cnt))
                visited[nx][ny][z] = 1
    return -1


N, M, K = map(int, input().split())
grid = [list(map(int, input().strip())) for _ in range(N)]
print(bfs())
```

## 풀이 방식
- 벽이 없어지는 다른 세계라고 생각하면 3차원 배열을 쉽게 접근할 수 있습니다.
- 1과 0일 경우 두가지 로직이 달라야 합니다.
    - 1(=벽)일 경우 벽을 부술 수 있는 횟수가 남았는지, 이미 부쉰 벽인지 확인해줍니다.
    - 0(=빈 공간)일 경우 그냥 가면 됩니다.


## 개선사항(GPT 참고)
- visited 생성 순서 및 참조 순서를 변경했습니다.
    - 기존 : 
        - 배열 생성 = `visited = [[[False] * M for _ in range(N)] for __ in range(K+1)]`
        - 참조 : `visited[z][nx][ny]`
    - 개선 :
        - 배열 생성 = `visited = [[[0] * (K+1) for _ in range(M)] for __ in range(N]`
        - 참조 : `visited[nx][ny][z]`
- `input = sys.stdin.readline`으로 입력 변경
- 입력 시 str -> int로 변경