### PR TITLE
[solve]: [BOJ] / 1238번 파티 문제풀이

### DIFF
--- a/seunghoon/BOJ/sol.py
+++ b/seunghoon/BOJ/sol.py
@@ -1,0 +1,41 @@
+from collections import deque
+import sys
+input = sys.stdin.readline
+def return_home():
+    q = deque([(0,x)])
+    home_way[x] = 0
+    while q:
+        m, student = q.popleft()
+        for way, time in students[student]:
+            move = m + time
+            if home_way[way] > move:
+                home_way[way] = move
+                q.append((move, way))
+
+def go_party():
+    q = deque([(0,x)])
+    party_way[x] = 0
+    while q:
+        m, student = q.popleft()
+        for way, time in students_reverse[student]:
+            move = m + time
+            if party_way[way] > move:
+                party_way[way] = move
+                q.append((move, way))
+
+n,m,x = map(int,input().split())
+students = [[] for _ in range(n+1)]
+students_reverse = [[] for _ in range(n+1)]
+home_way = [10000000000]*(n+1)
+party_way = [1000000000]*(n+1)
+for _ in range(m):
+    start,end,t = map(int,input().split())
+    students[start].append([end,t])
+    students_reverse[end].append([start,t])
+
+res = 0
+return_home()
+go_party()
+for i in range(1, n+1):
+    res = max(res, party_way[i] + home_way[i])
+print(res)


### PR DESCRIPTION
[BOJ] 1238:
    - 문제 유형 : 다익스트라
    - 문제 난이도 : 백준 골드 3
    - 시간 : readline 사용시 76, 일반 232ms
    - 공간복잡도 : 34984kb

## 문제 코드
```python
from collections import deque
import sys
input = sys.stdin.readline
def return_home():
    q = deque([(0,x)])
    home_way[x] = 0
    while q:
        m, student = q.popleft()
        for way, time in students[student]:
            move = m + time
            if home_way[way] > move:
                home_way[way] = move
                q.append((move, way))

def go_party():
    q = deque([(0,x)])
    party_way[x] = 0
    while q:
        m, student = q.popleft()
        for way, time in students_reverse[student]:
            move = m + time
            if party_way[way] > move:
                party_way[way] = move
                q.append((move, way))

n,m,x = map(int,input().split())
students = [[] for _ in range(n+1)]
students_reverse = [[] for _ in range(n+1)]
home_way = [10000000000]*(n+1)
party_way = [1000000000]*(n+1)
for _ in range(m):
    start,end,t = map(int,input().split())
    students[start].append([end,t])
    students_reverse[end].append([start,t])

res = 0
return_home()
go_party()
for i in range(1, n+1):
    res = max(res, party_way[i] + home_way[i])
print(res)
```

## 풀이 방식
- x -> 각각의 마을까지 최단거리 배열 생성
- 각각의 마을 -> x까지의 최단거리는 각각의 경로를 뒤집은 상태로 x -> 각각의 마을 최단거리와 일치. 따라서 이를 활용해 각각의 마을에서 x로 오는 최단거리 배열 생성
- 각각의 마을에서 두 배열의 값을 더해줬을때 최댓값을 구해준다.