### PR TITLE
[Solve] : [BOJ] 11659 구간 합 구하기4 - 문제 해결

### DIFF
--- a/Minwoo/BOJ/11569/sol.py
+++ b/Minwoo/BOJ/11569/sol.py
@@ -1,0 +1,12 @@
+import sys
+# sys.stdin = open('input.txt', 'r')
+input = sys.stdin.readline
+
+N, M = map(int, input().split())
+nums = list(map(int, input().split()))
+prefix_sum = [0]
+for i in range(N):
+    prefix_sum.append(nums[i] + prefix_sum[i])
+for i in range(M):
+    r, l = map(int, input().split())
+    print(prefix_sum[l] - prefix_sum[r-1])


### PR DESCRIPTION
- 제목 : [해결 여부] : [Solve] : [BOJ] 11659 구간 합 구하기4 - 문제 해결
- 내용 : 문제 링크, 풀이 코드, 풀이 방법 설명
    - 난이도: Silver 5
    - 분류 : 다이나믹 프로그래밍~~을 가장한 누적합~~
# [BOJ 11659 구간 합 구하기 4](https://www.acmicpc.net/problem/11659)
## 문제 코드
```python
N, M = map(int, input().split())
data = [list(map(int, input().split())) for _ in range(N)]
prefix = [[0] * (M+1) for _ in range(N+1)]
for i in range(1, N+1):
    for j in range(1, M+1):
        prefix[i][j] = data[i-1][j-1] + prefix[i-1][j] + prefix[i][j-1] - prefix[i-1][j-1]

for _ in range(int(input())):
    x1, y1, x2, y2 = map(int, input().split())
    base = prefix[x2][y2]
    dec1 = prefix[x2][y1-1]
    dec2 = prefix[x1-1][y2]
    inc = prefix[x1-1][y1-1]
    print(base - dec1 - dec2 + inc)
```

## 풀이 방식
- 누적합으로 접근합니다.
- 누적합(prefix)의 인덱스 0번째 행, 열은 모두 0으로 두고 1, 1부터 접근 가능하도록 했습니다.