### PR TITLE
[Solve] : [BOJ] 2636 치즈- 문제 해결

### DIFF
--- a/Minwoo/BOJ/2636/sol.py
+++ b/Minwoo/BOJ/2636/sol.py
@@ -1,0 +1,52 @@
+import sys
+sys.stdin = open('input.txt', 'r')
+from collections import deque
+dxy = (1, 0), (0, 1), (-1, 0), (0, -1)
+
+
+def bfs():
+    global grid, R, C
+    cnt = 0
+    queue = deque([(0, 0)])
+    visited = set()
+    visited.add((0, 0))
+    temp = []
+    while queue:
+        x, y = queue.popleft()
+        if grid[x][y] == 1:
+            temp.append((x, y))
+            cnt += 1
+            continue
+        for dx, dy in dxy:
+            nx, ny = x + dx, y + dy
+            if nx < 0 or nx >= R or ny < 0 or ny >= C or (nx, ny) in visited:
+                continue
+            queue.append((nx, ny))
+            visited.add((nx, ny))
+    for x, y in temp:
+        grid[x][y] = 0
+    return cnt
+
+
+def count_cheese():
+    global grid, R, C
+    cnt = 0
+    for i in range(R):
+        for j in range(C):
+            if grid[i][j] == 1:
+                cnt += 1
+    return cnt
+
+
+R, C = map(int, input().split())
+grid = [list(map(int, input().split())) for _ in range(R)]
+cheese, time = count_cheese(), 1
+while True:
+    decrease = bfs()
+    if cheese - decrease == 0:
+        break
+    time += 1
+    cheese -= decrease
+
+print(time, cheese, sep='\n')
+


### PR DESCRIPTION
- 제목 : [Solve] : [BOJ] 2636 치즈- 문제 해결
- 내용 : 문제 링크, 풀이 코드, 풀이 방법 설명
    - 난이도 : Gold 4
    - 분류 : 너비 우선 탐색

# [BOJ 2636 치즈](https://www.acmicpc.net/problem/2636)
## 문제 코드
```python
from collections import deque
dxy = (1, 0), (0, 1), (-1, 0), (0, -1)


def bfs():
    global grid, R, C
    cnt = 0
    queue = deque([(0, 0)])
    visited = set()
    visited.add((0, 0))
    temp = []
    while queue:
        x, y = queue.popleft()
        if grid[x][y] == 1:
            temp.append((x, y))
            cnt += 1
            continue
        for dx, dy in dxy:
            nx, ny = x + dx, y + dy
            if nx < 0 or nx >= R or ny < 0 or ny >= C or (nx, ny) in visited:
                continue
            queue.append((nx, ny))
            visited.add((nx, ny))
    for x, y in temp:
        grid[x][y] = 0
    return cnt


def count_cheese():
    global grid, R, C
    cnt = 0
    for i in range(R):
        for j in range(C):
            if grid[i][j] == 1:
                cnt += 1
    return cnt


R, C = map(int, input().split())
grid = [list(map(int, input().split())) for _ in range(R)]
cheese, time = count_cheese(), 1
while True:
    decrease = bfs()
    if cheese - decrease == 0:
        break
    time += 1
    cheese -= decrease

print(time, cheese, sep='\n')

```

## 풀이 방식
- 최초에 입력된 치즈의 개수를 확인합니다.
- BFS로 탐색합니다. 이때 리스트의 가장자리는 치즈가 없음이 보장되어 있으므로 시작점은 x가 0 or N 혹은 y가 0 or N인 경우 어디에서든 시작점으로 삼을 수 있습니다.
- 0(빈공간)을 탐색하면서 nx, ny가 1인 경우 방문처리를 합니다. 다만 1인 위치에서 델타탐색은 하지 않고 치즈 개수를 카운트합니다.
- BFS탐색이 끝나면 1인 위치들을 모두 0으로 바꿔줍니다.
- 반환받은 치즈의 개수와의 차가 0이 되는 시간과 0이 되기 전의 치즈 수를 출력합니다.