### PR TITLE
[Solve] : [BOJ] 2167 2차원 배열의 합 - 문제 해결

### DIFF
--- a/Minwoo/BOJ/2167/sol.py
+++ b/Minwoo/BOJ/2167/sol.py
@@ -1,0 +1,18 @@
+import sys
+# sys.stdin = open('input.txt', 'r')
+input = sys.stdin.readline
+
+N, M = map(int, input().split())
+data = [list(map(int, input().split())) for _ in range(N)]
+prefix = [[0] * (M+1) for _ in range(N+1)]
+for i in range(1, N+1):
+    for j in range(1, M+1):
+        prefix[i][j] = data[i-1][j-1] + prefix[i-1][j] + prefix[i][j-1] - prefix[i-1][j-1]
+
+for _ in range(int(input())):
+    x1, y1, x2, y2 = map(int, input().split())
+    base = prefix[x2][y2]
+    dec1 = prefix[x2][y1-1]
+    dec2 = prefix[x1-1][y2]
+    inc = prefix[x1-1][y1-1]
+    print(base - dec1 - dec2 + inc)


### PR DESCRIPTION
- 제목 : [Solve] : [BOJ] 2167 2차원 배열의 합 - 문제 해결
- 내용 : 문제 링크, 풀이 코드, 풀이 방법 설명
    - 난이도 : Silver 5
    - 분류 : 누적
# [BOJ 2167 2차원 배열의 합](https://www.acmicpc.net/problem/2167)
## 문제 코드
```python
import sys
input = sys.stdin.readline

N, M = map(int, input().split())
data = [list(map(int, input().split())) for _ in range(N)]
prefix = [[0] * (M+1) for _ in range(N+1)]
for i in range(1, N+1):
    for j in range(1, M+1):
        prefix[i][j] = data[i-1][j-1] + prefix[i-1][j] + prefix[i][j-1] - prefix[i-1][j-1]

for _ in range(int(input())):
    x1, y1, x2, y2 = map(int, input().split())
    base = prefix[x2][y2]
    dec1 = prefix[x2][y1-1]
    dec2 = prefix[x1-1][y2]
    inc = prefix[x1-1][y1-1]
    print(base - dec1 - dec2 + inc)

```

## 풀이 방식
- 누적합 배열을 만들고 좌표에서 값을 제외합니다.