### PR TITLE
[Solve] : [BOJ] 11660 구간 합 구하기 5 - 문제 해결

### DIFF
--- a/Minwoo/BOJ/11660/sol.py
+++ b/Minwoo/BOJ/11660/sol.py
@@ -1,0 +1,16 @@
+import sys
+# sys.stdin = open('input.txt', 'r')
+input = sys.stdin.readline
+
+N, M = map(int, input().split())
+data = [list(map(int, input().split())) for _ in range(N)]
+prefix_sum = [[0] * (N+1) for _ in range(N+1)]
+
+for i in range(1, N+1):
+    for j in range(1, N+1):
+        prefix_sum[i][j] = (data[i-1][j-1] + prefix_sum[i-1][j] + prefix_sum[i][j-1] - prefix_sum[i-1][j-1])
+for _ in range(M):
+    x1, y1, x2, y2 = map(int, input().split())
+    base = prefix_sum[x2][y2]
+    dec = prefix_sum[x1-1][y2] + prefix_sum[x2][y1-1] - prefix_sum[x1-1][y1-1]
+    print(base - dec)


### PR DESCRIPTION
- 제목 : [Solve] : [BOJ] 11660 구간 합 구하기 5 - 문제 해결
- 내용 : 문제 링크, 풀이 코드, 풀이 방법 설명
    - 난이도 : Silver 1
    - 분류 : 누적합

# [BOJ 11660 구간 합 구하기 5](https://www.acmicpc.net/problem/11660)
## 문제 코드
```python
import sys
input = sys.stdin.readline

N, M = map(int, input().split())
data = [list(map(int, input().split())) for _ in range(N)]
prefix_sum = [[0] * (N+1) for _ in range(N+1)]

for i in range(1, N+1):
    for j in range(1, N+1):
        prefix_sum[i][j] = (data[i-1][j-1]
                            + prefix_sum[i-1][j]
                            + prefix_sum[i][j-1]
                            - prefix_sum[i-1][j-1])
for _ in range(M):
    x1, y1, x2, y2 = map(int, input().split())
    base = prefix_sum[x2][y2]
    dec = prefix_sum[x1-1][y2] + prefix_sum[x2][y1-1] - prefix_sum[x1-1][y1-1]
    print(base - dec)
```

## 풀이 방식
- sys.stdin 없으면 안풀립니다.