### PR TITLE
[Solve] : [BOJ] 2477 참외밭 - 문제 해결

### DIFF
--- a/Minwoo/BOJ/2477/sol.py
+++ b/Minwoo/BOJ/2477/sol.py
@@ -1,0 +1,29 @@
+import sys
+sys.stdin = open("input.txt", "r")
+from collections import deque
+dic = {
+    (1, 3): (3, 1, 3, 1),
+    (2, 4): (4, 2, 4, 2),
+    (1, 4): (1, 4, 1, 4),
+    (2, 3): (2, 3, 2, 3)
+}
+
+N = 6
+K = int(input())
+queue = deque([list(map(int, input().split())) for _ in range(N)])
+num = [0] * 4
+idx = []
+for q in queue:
+    num[q[0]-1] += 1
+    if num[q[0]-1] > 1:
+        idx.append(q[0])
+idx.sort()
+tpl = (idx[0], idx[1])
+a, b, c, d = dic[tpl]
+while True:
+    if a == queue[0][0] and b == queue[1][0] and c == queue[2][0] and d == queue[3][0]:
+        break
+    queue.rotate(1)
+big = (queue[0][1]+queue[2][1]) * (queue[1][1]+queue[3][1])
+small = queue[1][1] * queue[2][1]
+print((big - small) * K)


### PR DESCRIPTION
- 제목 : [해결 여부] : [문제 사이트] 문제 번호 - 메세지
    - 예시 : [Solve] : [BOJ] 1405 - 경비원 문제풀이
- 내용 : 문제 링크, 풀이 코드, 풀이 방법 설명
    - 난이도 : Silver 2
    - 분류 : 수학 / 기하학 / 구현 ~~완전탐색(개인적으로 그렇다고 봅니다)~~
# [BOJ 2477 참외밭](https://www.acmicpc.net/problem/2477)
## 문제 코드
```python
from collections import deque
dic = {
    (1, 3): (3, 1, 3, 1),
    (2, 4): (4, 2, 4, 2),
    (1, 4): (1, 4, 1, 4),
    (2, 3): (2, 3, 2, 3)
}

N = 6
K = int(input())
queue = deque([list(map(int, input().split())) for _ in range(N)])
num = [0] * 4
idx = []
for q in queue:
    num[q[0]-1] += 1
    if num[q[0]-1] > 1:
        idx.append(q[0])
idx.sort()
tpl = (idx[0], idx[1])
a, b, c, d = dic[tpl]
while True:
    if a == queue[0][0] and b == queue[1][0] and c == queue[2][0] and d == queue[3][0]:
        break
    queue.rotate(1)
big = (queue[0][1]+queue[2][1]) * (queue[1][1]+queue[3][1])
small = queue[1][1] * queue[2][1]
print((big - small) * K)

```

## 풀이 방식
- queue의 rotate 기능을 이용해서 순서를 일정하게 만듭니다.
- 문제에서는 반시계 방향으로 입력이 주어진다고 했습니다. 따라서 참외밭이 6각형이 되도록 입력이 되는 경우는
1. `1 4 1 4 2 3`
2. `4 2 4 2 3 1`
3. `2 3 2 3 1 4`
4. `3 1 3 1 4 2`
- 총 4가지 이며 이중 같은 숫자가 연속되서 나올 수 있도록 회전시켰습니다.
- 그러면 중간에 있는 두 수로 전체 너비 - 제외해야 할 면적 * K로 출력합니다.