### PR TITLE
[Solve] : [BOJ] 7569 토마토(3차원) - 문제 해결

### DIFF
--- a/Minwoo/BOJ/7569/sol.py
+++ b/Minwoo/BOJ/7569/sol.py
@@ -1,0 +1,45 @@
+import sys
+# sys.stdin = open('input.txt', 'r')
+input = sys.stdin.readline
+from collections import deque
+dxy = (1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)
+
+
+def bfs(st):
+    global tomato, N, M, H, visited, dxy
+    queue = deque(st)
+    cnt = 0
+    time = 1
+    while queue:
+        x, y, z = queue.popleft()
+        time = visited[x][y][z]
+        cnt += 1
+        for dx, dy, dz in dxy:
+            nx, ny, nz = x + dx, y + dy, z + dz
+            if not(0 <= nx < N and 0 <= ny < M and 0 <= nz < H):
+                continue
+            if visited[nx][ny][nz]: continue
+            if tomato[nz][nx][ny] in [-1, 1]: continue
+            queue.append((nx, ny, nz))
+            visited[nx][ny][nz] = 1 + visited[x][y][z]
+    return cnt, time-1
+
+
+M, N, H = map(int, input().split())
+tomato = [[list(map(int, input().split())) for _ in range(N)] for __ in range(H)]
+start = []
+tomato_count = 0
+visited = [[[0] * H for ____ in range(M)] for ___ in range(N)]
+for k in range(H):
+    for r in range(N):
+        for c in range(M):
+            if tomato[k][r][c] == 1:
+                start.append((r, c, k))
+                visited[r][c][k] = 1
+                tomato_count += 1
+            elif tomato[k][r][c] == 0:
+                tomato_count += 1
+
+check, pp = bfs(start)
+print(pp if tomato_count - check == 0 else -1)
+


### PR DESCRIPTION
- 내용 : 문제 링크, 풀이 코드, 풀이 방법 설명
    - 난이도 : Gold 5
    - 분류 : 너비 우선 탐색
    - Runtime : pypy일때 884ms, python일 때 1860ms

# [BOJ 7569 🍅](https://www.acmicpc.net/problem/7569)

## 문제 코드
```python
import sys
input = sys.stdin.readline
from collections import deque
dxy = (1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)


def bfs(st):
    global tomato, N, M, H, visited, dxy
    queue = deque(st)
    cnt = 0
    time = 1
    while queue:
        x, y, z = queue.popleft()
        time = visited[x][y][z]
        cnt += 1
        for dx, dy, dz in dxy:
            nx, ny, nz = x + dx, y + dy, z + dz
            if not(0 <= nx < N and 0 <= ny < M and 0 <= nz < H):
                continue
            if visited[nx][ny][nz]: continue
            if tomato[nz][nx][ny] in [-1, 1]: continue
            queue.append((nx, ny, nz))
            visited[nx][ny][nz] = 1 + visited[x][y][z]
    return cnt, time-1


M, N, H = map(int, input().split())
tomato = [[list(map(int, input().split())) for _ in range(N)] for __ in range(H)]
start = []
tomato_count = 0
visited = [[[0] * H for ____ in range(M)] for ___ in range(N)]
for k in range(H):
    for r in range(N):
        for c in range(M):
            if tomato[k][r][c] == 1:
                start.append((r, c, k))
                visited[r][c][k] = 1
                tomato_count += 1
            elif tomato[k][r][c] == 0:
                tomato_count += 1

check, pp = bfs(start)
print(pp if tomato_count - check == 0 else -1)

```

## 풀이 방식
- 첫 시도에 UnboundLocalError를 목도하고 time이 갱신이 되지 않는 경우를 생각했습니다. 그래서 time 변수를 while문이 실행되지 않았을 때를 대비해서 선언하니까 되네요.
1. 입력은 3차원으로 받습니다. 이때 인덱스 접근은 [높이][가로][세로]입니다.
2. visited는 조회를 빠르게 하고자 [가로][세로][높이] 형태로 생성했습니다.
3. bfs 탐색으로 탐색한 토마토의 개수와 전체 토마토 개수에 0이 아닌 숫자가 나오면 -1을, 아닐 경우 가장 마지막에 갱신된 time-1을 출력합니다.