### PR TITLE
[Solve] : [BOJ] 16724 - 피리부는 사나이 문제 해결

### DIFF
--- a/kimchaejun/BOJ/16724/sol.py
+++ b/kimchaejun/BOJ/16724/sol.py
@@ -1,0 +1,23 @@
+def dfs(x, y):
+    global res
+    visited[x][y] = 1
+    dx, dy = dxy[num[field[x][y]]]
+    nx, ny = x + dx, y + dy
+    if not visited[nx][ny]:
+        dfs(nx, ny)
+    elif visited[nx][ny] == 1:
+        res += 1
+    visited[x][y] = 2
+
+
+N, M = map(int, input().split())
+field = [list(map(str, input().strip())) for _ in range(N)]
+dxy = [[0, 1], [0, -1], [1, 0], [-1, 0]]
+num = {'R': 0, 'L': 1, 'D': 2, 'U': 3}
+visited = [[0]*M for _ in range(N)]
+res = 0
+for i in range(N):
+    for j in range(M):
+        if not visited[i][j]:
+            dfs(i, j)
+print(res)


### PR DESCRIPTION
## 문제 정보
목차 | 정보
:--: | :--:
난이도 | 골드 3
알고리즘 분류 | 자료 구조 / 그래프 이론 / 그래프 탐색 / DFS / 분리 집합
링크 | [[BOJ] 16724 - 피리부는 사나이](https://www.acmicpc.net/problem/16724)

## 문제 코드
```python
def dfs(x, y):
    global res
    visited[x][y] = 1
    dx, dy = dxy[num[field[x][y]]]
    nx, ny = x + dx, y + dy
    if not visited[nx][ny]:
        dfs(nx, ny)
    elif visited[nx][ny] == 1:
        res += 1
    visited[x][y] = 2


N, M = map(int, input().split())
field = [list(map(str, input().strip())) for _ in range(N)]
dxy = [[0, 1], [0, -1], [1, 0], [-1, 0]]
num = {'R': 0, 'L': 1, 'D': 2, 'U': 3}
visited = [[0]*M for _ in range(N)]
res = 0
for i in range(N):
    for j in range(M):
        if not visited[i][j]:
            dfs(i, j)
print(res)
```

## 풀이 방식
- U, D, L, R 각각의 글자에 번호를 매겨주고, 동일한 인덱스 자리에 델타 탐색 좌표 작성
- 중첩 for문을 돌면서 방문한 적 없는 곳을 시작지점으로 하여 DFS 탐색한다.
- visited에 탐색한 지역은 1을 입력한다.
- 1을 만났다는 것은 즉, 한 사이클이 완성되었다는 뜻이 된다.
- 사이클이 완성된 시점에 탐색을 시작한 지점에 2를 할당하여 추가적인 탐색이 진행되지 않게 한다.
- res를 1 증가시킨다.
- 탐색 종료 후 res를 출력한다

## 시간 복잡도 (GPT 사용)
케이스 | 설명 | 시간 복잡도
-- | -- | --
최선 (Best) | 모든 칸이 DFS 한 번으로 이어져 있음 (한 번에 전체 방문) | O(N × M)
평균 (Avg) | 다수의 작은 사이클/경로가 있는 일반적인 경우 | O(N × M)
최악 (Worst) | 각 칸이 독립된 사이클이거나 최대로 나뉘어 있음. 여전히 한 번씩만 탐색 | O(N × M)