### PR TITLE
[Solve] : [BOJ] 18242 - 네모네모 시력 검사 문제 해결

### DIFF
--- a/kimchaejun/BOJ/18242/sol.py
+++ b/kimchaejun/BOJ/18242/sol.py
@@ -1,0 +1,15 @@
+N, M = map(int, input().split())
+matrix = [input() for _ in range(N)]
+matrix90 = list(map(list, zip(*matrix[::-1])))
+res_dict = {0: 'UP', 1: 'DOWN', 2: 'LEFT', 3: 'RIGHT'}
+up_down, left_right = [], []
+for i in range(N):
+    tmp = matrix[i].count('#')
+    if tmp > 2:
+        up_down.append(tmp)
+for i in range(M):
+    tmp90 = matrix90[i].count('#')
+    if tmp90 > 2:
+        left_right.append(tmp90)
+res = up_down + left_right
+print(res_dict[res.index(min(res))])


### PR DESCRIPTION
## 문제 정보
목차 | 정보
:--: | :--:
난이도 | 실버 4
알고리즘 분류 | 구현 / 애드 혹
링크 | [[BOJ] 18242 - 네모네모 시력 검사](https://www.acmicpc.net/problem/18242)

## 문제 코드
```python
N, M = map(int, input().split())
matrix = [input() for _ in range(N)]
matrix90 = list(map(list, zip(*matrix[::-1])))
res_dict = {0: 'UP', 1: 'DOWN', 2: 'LEFT', 3: 'RIGHT'}
up_down, left_right = [], []
for i in range(N):
    tmp = matrix[i].count('#')
    if tmp > 2:
        up_down.append(tmp)
for i in range(M):
    tmp90 = matrix90[i].count('#')
    if tmp90 > 2:
        left_right.append(tmp90)
res = up_down + left_right
print(res_dict[res.index(min(res))])
```

## 풀이 방식
- 요점은 개수가 다른 방향만 출력하면 된다!
- 왼쪽, 오른쪽 구분을 편하게 하기 위해 원본을 90도 뒤집은 2차원 배열을 하나 더 만든다.
- 원본은 N만큼, 90도 회전본은 M만큼 반복문을 돌면서 각 줄의 ```#```개수를 센다.
- 이때, 숫자가 2보다 크면 (사각형이라서 2라는 값이 무조건 발생함, 필요 없기 때문에 제외)
- 위, 아래의 ```#```개수를 저장한 변수와 왼쪽, 오른쪽의 ```#```개수를 저장한 변수를 더하여 하나의 배열로 만든다.
- 가장 작은 숫자의 인덱스 번호를 키값으로 하여 res_dict에 저장되어 있는 값을 출력한다.

## 시간 복잡도 (GPT 사용)
케이스 | 설명 | 최종 시간 복잡도
:--: | :--: | :--:
최악 | 각 count('#') 연산이 O(M) 또는 O(N)이며, 모든 행과 열에서 #가 많음 | O(N * M)
평균 | 각 count('#') 연산이 O(M) 또는 O(N)이며, #가 중간 정도로 분포 | O(N * M)
최선 | 각 count('#') 연산이 O(1) 또는 O(N), O(M)이며, #가 적거나 없음 | O(N * M)
