### PR TITLE
[Solve]:[BOJ] 인구 이동 문제 해결

### DIFF
--- a/jinhyeon/BOJ/16234/sol.py
+++ b/jinhyeon/BOJ/16234/sol.py
@@ -1,0 +1,48 @@
+from collections import deque
+n, l, r = map(int, input().split())
+dxl = [1, -1, 0, 0]
+dyl = [0, 0, 1, -1]
+arr = [list(map(int, input().split())) for _ in range(n)]
+
+cnt = 0
+def bfs(i, j):
+    bfs_q = deque()
+    q = deque()
+    bfs_q.append((i, j))
+    q.append((i, j))
+
+    visited[i][j] = 1
+    total = arr[i][j]
+
+    flag = False
+    while bfs_q:
+        x, y = bfs_q.popleft()
+        for dx, dy in zip(dxl, dyl):
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < n and 0 <= ny < n \
+                    and not visited[nx][ny] and l <= abs(arr[x][y] - arr[nx][ny]) <= r:
+                flag = True
+                bfs_q.append((nx, ny))
+                q.append((nx, ny))
+                total += arr[nx][ny]
+                visited[nx][ny] = 1
+
+    fed_len = len(q)
+    pop_one = total // fed_len
+    while q:
+        x, y = q.popleft()
+        arr[x][y] = pop_one
+    return flag
+
+while True:
+    visited = [[0] * n for _ in range(n)]
+    flag = False
+    for i in range(n):
+        for j in range(n):
+            if not visited[i][j]:
+                flag = True if bfs(i, j) else flag
+
+    if not flag:
+        break
+    cnt += 1
+print(cnt)


### PR DESCRIPTION
[BOJ] 16234:
    - 문제유형: 시뮬레이션, 구현, bfs
    - 문제난이도: 백준 골드 4
    - 시간복잡도: 1304ms
    - 공간복잡도: 133mb

[👨‍👨‍👧‍👧 👨‍👨‍👧‍👧 | 👨‍👨‍👧‍👧 👨‍👨‍👧‍👧
👨‍👨‍👧‍👧 👨‍👨‍👧‍👧 | 👨‍👨‍👧‍👧 👨‍👨‍👧‍👧
- - - -  ^ ^ ^ 
👨‍👨‍👧‍👧 👨‍👨‍👧‍👧 | 👨‍👨‍👧‍👧 👨‍👨‍👧‍👧
👨‍👨‍👧‍👧 👨‍👨‍👧‍👧 | 👨‍👨‍👧‍👧 👨‍👨‍👧‍👧](https://www.acmicpc.net/problem/16234)
## 문제 코드
```python
from collections import deque
n, l, r = map(int, input().split())
dxl = [1, -1, 0, 0]
dyl = [0, 0, 1, -1]
arr = [list(map(int, input().split())) for _ in range(n)]

cnt = 0
def bfs(i, j):
    bfs_q = deque()
    q = deque()
    bfs_q.append((i, j))
    q.append((i, j))

    visited[i][j] = 1
    total = arr[i][j]

    flag = False
    while bfs_q:
        x, y = bfs_q.popleft()
        for dx, dy in zip(dxl, dyl):
            nx, ny = x + dx, y + dy
            if 0 <= nx < n and 0 <= ny < n \
                    and not visited[nx][ny] and l <= abs(arr[x][y] - arr[nx][ny]) <= r:
                flag = True
                bfs_q.append((nx, ny))
                q.append((nx, ny))
                total += arr[nx][ny]
                visited[nx][ny] = 1

    fed_len = len(q)
    pop_one = total // fed_len
    while q:
        x, y = q.popleft()
        arr[x][y] = pop_one
    return flag

while True:
    visited = [[0] * n for _ in range(n)]
    flag = False
    for i in range(n):
        for j in range(n):
            if not visited[i][j]:
                flag = True if bfs(i, j) else flag

    if not flag:
        break
    cnt += 1
print(cnt)
```

## 풀이 방식
- bfs로 조건에 맞는 주변 국들 탐색하고 다른 큐에 저장 (리스트에 저장해도 됨)
- bfs 탐색이 끝난다면 인구 평균 내고 다시 리스트 순회하며 인구 분포시킴
- 그걸 while문 안의 이중 for문 안에서 반복한다