### PR TITLE
[Solve] : [BOJ] 16933 벽 부수고 이동하기 3 - 문제 해결

### DIFF
--- a/Minwoo/BOJ/16933/sol.py
+++ b/Minwoo/BOJ/16933/sol.py
@@ -1,0 +1,40 @@
+import sys
+sys.stdin = open('input.txt', 'r')
+input = sys.stdin.readline
+
+
+def bfs():
+    global N, M, K, grid
+    dxy = (1, 0), (0, 1), (-1, 0), (0, -1)
+    visited = [[[0] * M for _ in range(N)] for __ in range(K+1)]
+    queue = [(0, 0, K)]
+    visited[K][0][0] = 1
+    day_night = 1
+    cnt = 0
+    while queue:
+        temp = []
+        day_night = 1 - day_night
+        cnt += 1
+        for x, y, z in queue:
+            if x == N-1 and y == M-1:
+                return cnt
+            for dx, dy in dxy:
+                nx, ny = x + dx, y + dy
+                if nx < 0 or nx >= N or ny < 0 or ny >= M:
+                    continue
+                if grid[nx][ny] == 1 and z > 0 and visited[z-1][nx][ny] == 0:
+                    if day_night == 0:
+                        temp.append((nx, ny, z-1))
+                        visited[z-1][nx][ny] = 1
+                    else:
+                        temp.append((x, y, z))
+                elif grid[nx][ny] == 0 and visited[z][nx][ny] == 0:
+                    temp.append((nx, ny, z))
+                    visited[z][nx][ny] = 1
+        queue = temp
+    return -1
+
+
+N, M, K = map(int, input().split())
+grid = [list(map(int, input().strip())) for _ in range(N)]
+print(bfs())


### PR DESCRIPTION
# [BOJ 16933 - 벽 부수고 이동하기 3](https://www.acmicpc.net/problem/16933)

## 문제 코드
```python
import sys
sys.stdin = open('input.txt', 'r')
input = sys.stdin.readline


def bfs():
    global N, M, K, grid
    dxy = (1, 0), (0, 1), (-1, 0), (0, -1)
    visited = [[[0] * M for _ in range(N)] for __ in range(K+1)]
    queue = [(0, 0, K)]
    visited[K][0][0] = 1
    day_night = 1
    cnt = 0
    while queue:
        temp = []
        day_night = 1 - day_night
        cnt += 1
        for x, y, z in queue:
            if x == N-1 and y == M-1:
                return cnt
            for dx, dy in dxy:
                nx, ny = x + dx, y + dy
                if nx < 0 or nx >= N or ny < 0 or ny >= M:
                    continue
                if grid[nx][ny] == 1 and z > 0 and visited[z-1][nx][ny] == 0:
                    if day_night == 0:
                        temp.append((nx, ny, z-1))
                        visited[z-1][nx][ny] = 1
                    else:
                        temp.append((x, y, z))
                elif grid[nx][ny] == 0 and visited[z][nx][ny] == 0:
                    temp.append((nx, ny, z))
                    visited[z][nx][ny] = 1
        queue = temp
    return -1


N, M, K = map(int, input().split())
grid = [list(map(int, input().strip())) for _ in range(N)]
print(bfs())

```

## 풀이 방식
- queue는 말만 queue인데 그냥 리스트입니다.
- 밤일 경우 벽을 부쉴 수 없다고 해서 그 자리 그대로 머무르게 했습니다. 여기서 최적화를 한다면 리스트에 저장할때 현재 낮과 밤에 대한 여부를 함께 저장해 한칸 머무르는게 아니라, 머무르는 시간까지 더하고, 낮에 이동해서 다시 밤이 되는 경우를 고려하면 좋을 것 같습니다.