### PR TITLE
[Solve] : [BOJ] 14938 서강그라운드 - 문제 해결

### DIFF
--- a/Minwoo/BOJ/14938/sol.py
+++ b/Minwoo/BOJ/14938/sol.py
@@ -1,0 +1,39 @@
+import sys
+import heapq
+sys.stdin = open('input.txt', 'r')
+input = sys.stdin.readline
+
+
+def dijkstra(stv):
+    global graph, R, MAP, M
+    distances = {v: float('inf') for v in range(1, N + 1)}
+    queue = [(0, stv)]
+    heapq.heapify(queue)
+    distances[stv] = 0
+    cnt = 0
+    while queue:
+        dist, vtx = heapq.heappop(queue)
+        if dist > distances[vtx]: continue
+        for adj, w in graph[vtx]:
+            acc = dist + w
+            if distances[adj] <= acc: continue
+            heapq.heappush(queue, (acc, adj))
+            distances[adj] = acc
+    for i in range(1, N+1):
+        if distances[i] <= M:
+            cnt += MAP[i-1]
+    return cnt
+
+
+N, M, R = map(int, input().split())
+MAP = list(map(int, input().split()))
+graph = {v: [] for v in range(1, N+1)}
+for _ in range(R):
+    x, y, z = map(int, input().split())
+    graph[x].append((y, z))
+    graph[y].append((x, z))
+result = 0
+for i in range(1, N+1):
+    result = max(result, dijkstra(i))
+print(result)
+


### PR DESCRIPTION
# [BOJ 14938 - 서강그라운](https://www.acmicpc.net/problem/14938)
    - 문제 분류 : 다익스트라
    - 난이도 : Gold 4


## 문제 코드
```python
import sys
import heapq
input = sys.stdin.readline


def dijkstra(stv):
    global graph, R, MAP, M
    distances = {v: float('inf') for v in range(1, N + 1)}
    queue = [(0, stv)]
    heapq.heapify(queue)
    distances[stv] = 0
    cnt = 0
    while queue:
        dist, vtx = heapq.heappop(queue)
        if dist > distances[vtx]: continue
        for adj, w in graph[vtx]:
            acc = dist + w
            if distances[adj] <= acc: continue
            heapq.heappush(queue, (acc, adj))
            distances[adj] = acc
    for i in range(1, N+1):
        if distances[i] <= M:
            cnt += MAP[i-1]
    return cnt


N, M, R = map(int, input().split())
MAP = list(map(int, input().split()))
graph = {v: [] for v in range(1, N+1)}
for _ in range(R):
    x, y, z = map(int, input().split())
    graph[x].append((y, z))
    graph[y].append((x, z))
result = 0
for i in range(1, N+1):
    result = max(result, dijkstra(i))
print(result)
```

## 풀이 방식
- 처음에 문제 요구사항이 뭔지 몰라서 몇 번 틀렸습니다
- 가중치가 수색 범위(M) 이내인 정점에서 획득 가능한 아이템의 개수를 모두 더해서 출력합니다.