### PR TITLE
[Solve] : [BOJ] 18352 최소 비용 구하기2 - 문제 해결

### DIFF
--- a/Minwoo/BOJ/11779/sol.py
+++ b/Minwoo/BOJ/11779/sol.py
@@ -1,0 +1,35 @@
+import sys
+import heapq
+sys.stdin = open('input.txt', 'r')
+input = sys.stdin.readline
+
+
+def dijkstra():
+    global graph, distance, stv, edv
+    queue = [(0, stv, [stv])]
+    distance[stv] = 0
+    temp = []
+    while queue:
+        dist, vtx, channel = heapq.heappop(queue)
+        if dist > distance[vtx]: continue
+        for adj, w in graph[vtx]:
+            if (acc := dist + w) >= distance[adj]:
+                continue
+            heapq.heappush(queue, (acc, adj, channel+[adj]))
+            distance[adj] = acc
+            if adj == edv:
+                temp = channel + [adj]
+    return temp
+
+
+N = int(input())
+graph = {v: [] for v in range(1, N+1)}
+for _ in range(int(input())):
+    x, y, z = map(int, input().split())
+    graph[x].append((y, z))
+stv, edv = map(int, input().split())
+distance = {v: float('inf') for v in range(1, N+1)}
+short_channel = dijkstra()
+print(distance[edv])
+print(len(short_channel))
+print(*short_channel)


### PR DESCRIPTION
# [BOJ 18352 - 최소 비용 구하기2](https://www.acmicpc.net/problem/11779)
    - 난이도 : Gold 3
    - 분류 :  다익스트라


## 문제 코드
```python
import sys
import heapq
sys.stdin = open('input.txt', 'r')
input = sys.stdin.readline


def dijkstra():
    global graph, distance, stv, edv
    queue = [(0, stv, [stv])]
    distance[stv] = 0
    temp = []
    while queue:
        dist, vtx, channel = heapq.heappop(queue)
        if dist > distance[vtx]: continue
        for adj, w in graph[vtx]:
            if (acc := dist + w) >= distance[adj]:
                continue
            heapq.heappush(queue, (acc, adj, channel+[adj]))
            distance[adj] = acc
            if adj == edv:
                temp = channel + [adj]
    return temp


N = int(input())
graph = {v: [] for v in range(1, N+1)}
for _ in range(int(input())):
    x, y, z = map(int, input().split())
    graph[x].append((y, z))
stv, edv = map(int, input().split())
distance = {v: float('inf') for v in range(1, N+1)}
short_channel = dijkstra()
print(distance[edv])
print(len(short_channel))
print(*short_channel)

```
## 문제 풀이
- 출력은 도착점까지 최소 비용 / 경로에 포함된 도시의 개수 / 최소 비용으로 이동하는 경로상의 도시를 순서대로 출력하는데 아무거나
- 한줄 줄여보고 싶어서 `(acc := dist+w)`를 썼는데 바다코끼리 연산자라고 해서 lambda랑 비슷한 친구인데  `:=` 이전 식을 acc에 할당해준다고 생각하면 됩니다.